### PR TITLE
fix bitmap flipping

### DIFF
--- a/lib/images/bitmap.js
+++ b/lib/images/bitmap.js
@@ -144,7 +144,6 @@ wdi.BMP2 = $.spcExtend(wdi.SpiceObject, {
 				}
 
 			} else if (type === wdi.SpiceBitmapFmt.SPICE_BITMAP_FMT_RGBA) {
-				topdown = true;
 				for (pos = 0; pos < size; pos+=4) {
 					b = data[pos];
 					data[pos] = data[pos+2];


### PR DESCRIPTION
Hi guys,

Discovered a flipping issue while working on integrating eyeOS web client into kimchi.
Current code in this fork already honestly sets the topdown from server flag so no reason to set it explicitly anymore.