### PR TITLE
bytesToURI:URL.createObjectURL issue 

### DIFF
--- a/lib/rasterEngine.js
+++ b/lib/rasterEngine.js
@@ -65,30 +65,30 @@ wdi.RasterEngine = $.spcExtend(wdi.EventObject.prototype, {
 		var img = wdi.GlobalPool.create('Image'); //auto-release pool
 		wdi.ExecutionControl.sync = true;
 		var url;
-		img.onload = function() {
-			URL.revokeObjectURL(url);
-			var box = stream.computedBox;
-			// we only rotate the stream if spice tells us so through the TOP_DOWN flag mask
-			if (!(stream.flags & wdi.SpiceStreamFlags.SPICE_STREAM_FLAGS_TOP_DOWN)) {
-				var offsetX = box.x + (this.width/2);
-				var offsetY = box.y + (this.height/2);
-				context.save();
-				context.translate(offsetX, offsetY);
-				context.rotate(Math.PI);
-				context.scale(-1,1);
-				context.drawImage(this, box.x-offsetX, box.y-offsetY, box.width, box.height);
-				context.restore();
-			} else {
-				context.drawImage(this, box.x, box.y, box.width, box.height);
-			}
-		};
-
 		img.onerror = function() {
 			URL.revokeObjectURL(url)
 		};
-
-		url = wdi.SpiceObject.bytesToURI(imageData);
-		img.src = url;
+		//bytesToURI return Promise
+		wdi.SpiceObject.bytesToURI(imageData).then(res=>{
+			img.onload = function() {
+				URL.revokeObjectURL(url);
+				var box = stream.computedBox;
+				// we only rotate the stream if spice tells us so through the TOP_DOWN flag mask
+				if (!(stream.flags & wdi.SpiceStreamFlags.SPICE_STREAM_FLAGS_TOP_DOWN)) {
+					var offsetX = box.x + (this.width/2);
+					var offsetY = box.y + (this.height/2);
+					context.save();
+					context.translate(offsetX, offsetY);
+					context.rotate(Math.PI);
+					context.scale(-1,1);
+					context.drawImage(this, box.x-offsetX, box.y-offsetY, box.width, box.height);
+					context.restore();
+				} else {
+					context.drawImage(this, box.x, box.y, box.width, box.height);
+				}
+			};
+			img.src = res;
+		});
 	},
 
 	handleStreamClip: function(spiceMessage) {

--- a/spiceobjects/spiceobjects.js
+++ b/spiceobjects/spiceobjects.js
@@ -48,7 +48,21 @@ wdi.SpiceObject = {
 
     bytesToURI: function (data) {
         var blob = new Blob([data], {type: "image/jpeg"});
-        return URL.createObjectURL(blob);
+        /**
+         * reason: The performance of 'URL.createObjectURL' is better than 'reader.readAsDataURL' ,
+         * but 'URL.createObjectURL' will download picture in memory and it can not be cleared.
+         * 'reader.readAsDataURL' will generate base64 code and auto GC.If we use 'URL.createObjectURL' here,
+         * When the remote desktop is running long time and image chaning always,it will be out of memory.
+         *
+         */
+        return  new Promise((resolve, reject) => {
+            const reader  = new FileReader();
+            reader.readAsDataURL(blob);
+            reader.onload=function(){
+                resolve(reader.result);
+            };
+        })
+        // return URL.createObjectURL(blob);
     },
 
     bytesToStringBE: function (bytes, nbytes) {


### PR DESCRIPTION
```
bytesToURI: function (data) {
        var blob = new Blob([data], {type: "image/jpeg"});
        /**
         * reason: The performance of 'URL.createObjectURL' is better than 'reader.readAsDataURL' ,
         * but 'URL.createObjectURL' will download picture in memory and it can not be cleared.
         * 'reader.readAsDataURL' will generate base64 code and auto GC.If we use 'URL.createObjectURL' here,
         * When the remote desktop is running long time and image chaning always,it will be out of memory.
         *
         */
        return  new Promise((resolve, reject) => {
            const reader  = new FileReader();
            reader.readAsDataURL(blob);
            reader.onload=function(){
                resolve(reader.result);
            };
        })
        // return URL.createObjectURL(blob);
    },
```